### PR TITLE
Fix typo in trove classifier for language

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: Implementation : CPython",
+    "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Information Analysis"
 ]
 


### PR DESCRIPTION
I had a single colon as the last separator in the language classifier. This should have been a double colon.  However, it really shouldn't be language-specific at all, so I changed it to just specify Python 3.

Closes #3 

